### PR TITLE
PDA-143: Fix task comment creation

### DIFF
--- a/src/main/java/org/entando/plugins/pda/pam/service/process/KieProcessFormService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/process/KieProcessFormService.java
@@ -68,9 +68,7 @@ public class KieProcessFormService implements ProcessFormService {
             return client.startProcess(id.getContainerId(), id.getDefinitionId(), variables)
                     .toString();
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new ProcessDefinitionNotFoundException(e);
             }
 

--- a/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class KieTaskCommentService implements TaskCommentService {
 
-    public static final String PDA_PREFIX = "pda_";
+    public static final String PDA_USER_PREFIX = "user_";
 
     private final KieApiService kieApiService;
     private final CustomQueryService customQueryService;
@@ -84,7 +84,7 @@ public class KieTaskCommentService implements TaskCommentService {
             // add prefix if username clashes with group name
             List<String> groups = customQueryService.getGroups(connection, createdBy);
             if (CollectionUtils.isNotEmpty(groups)) {
-                createdBy = PDA_PREFIX + createdBy; //NOPMD: String concatenation is better here
+                createdBy = PDA_USER_PREFIX + createdBy; //NOPMD: String concatenation is better here
             }
             Long commentId = client.addTaskComment(taskId.getContainerId(), taskId.getInstanceId(),
                     request.getComment(), createdBy, createdAt);

--- a/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
@@ -44,9 +44,7 @@ public class KieTaskCommentService implements TaskCommentService {
                     .map(KieTaskCommentService::dtoToComment)
                     .collect(Collectors.toList());
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new TaskNotFoundException(e);
             }
 
@@ -65,9 +63,7 @@ public class KieTaskCommentService implements TaskCommentService {
 
             return dtoToComment(comment);
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new CommentNotFoundException(e);
             }
 
@@ -116,9 +112,7 @@ public class KieTaskCommentService implements TaskCommentService {
             client.deleteTaskComment(taskId.getContainerId(), taskId.getInstanceId(), Long.valueOf(commentId));
             return commentId;
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new CommentNotFoundException(e);
             }
 

--- a/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.entando.keycloak.security.AuthenticatedUser;
 import org.entando.plugins.pda.core.engine.Connection;
 import org.entando.plugins.pda.core.exception.CommentNotFoundException;
@@ -13,6 +14,7 @@ import org.entando.plugins.pda.core.model.Comment;
 import org.entando.plugins.pda.core.service.task.TaskCommentService;
 import org.entando.plugins.pda.core.service.task.request.CreateCommentRequest;
 import org.entando.plugins.pda.pam.exception.KieInvalidResponseException;
+import org.entando.plugins.pda.pam.service.api.CustomQueryService;
 import org.entando.plugins.pda.pam.service.api.KieApiService;
 import org.entando.plugins.pda.pam.service.util.KieInstanceId;
 import org.kie.server.api.exception.KieServicesHttpException;
@@ -26,7 +28,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class KieTaskCommentService implements TaskCommentService {
 
+    public static final String PDA_PREFIX = "pda_";
+
     private final KieApiService kieApiService;
+    private final CustomQueryService customQueryService;
 
     @Override
     public List<Comment> listComments(Connection connection, AuthenticatedUser user, String id) {
@@ -80,6 +85,11 @@ public class KieTaskCommentService implements TaskCommentService {
         Date createdAt = new Date();
 
         try {
+            // add prefix if username clashes with group name
+            List<String> groups = customQueryService.getGroups(connection, createdBy);
+            if (CollectionUtils.isNotEmpty(groups)) {
+                createdBy = PDA_PREFIX + createdBy; //NOPMD: String concatenation is better here
+            }
             Long commentId = client.addTaskComment(taskId.getContainerId(), taskId.getInstanceId(),
                     request.getComment(), createdBy, createdAt);
 
@@ -90,12 +100,9 @@ public class KieTaskCommentService implements TaskCommentService {
                     .createdBy(createdBy)
                     .build();
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new TaskNotFoundException(e);
             }
-
             throw new KieInvalidResponseException(HttpStatus.valueOf(e.getHttpCode()), e.getMessage(), e);
         }
     }

--- a/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskFormService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskFormService.java
@@ -47,9 +47,7 @@ public class KieTaskFormService implements TaskFormService {
             String json = client.getTaskForm(taskId.getContainerId(), taskId.getInstanceId());
             return MAPPER.readValue(json, Form.class);
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new TaskNotFoundException(e);
             }
             throw new KieInvalidResponseException(HttpStatus.valueOf(e.getHttpCode()), e.getMessage(), e);
@@ -71,9 +69,7 @@ public class KieTaskFormService implements TaskFormService {
             client.saveTaskContent(taskId.getContainerId(), taskId.getInstanceId(), variables);
             return id;
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new TaskNotFoundException(e);
             }
 

--- a/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskService.java
+++ b/src/main/java/org/entando/plugins/pda/pam/service/task/KieTaskService.java
@@ -142,9 +142,7 @@ public class KieTaskService implements TaskService {
 
             return KieTaskDetails.from(task);
         } catch (KieServicesHttpException e) {
-            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())
-                    //Some endpoints return 500 instead of 404
-                    || e.getHttpCode().equals(HttpStatus.INTERNAL_SERVER_ERROR.value())) {
+            if (e.getHttpCode().equals(HttpStatus.NOT_FOUND.value())) {
                 throw new TaskNotFoundException(e);
             }
 

--- a/src/test/java/org/entando/plugins/pda/pam/service/process/KieProcessFormServiceTest.java
+++ b/src/test/java/org/entando/plugins/pda/pam/service/process/KieProcessFormServiceTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.entando.plugins.pda.core.engine.Connection;
 import org.entando.plugins.pda.core.exception.ProcessDefinitionNotFoundException;
 import org.entando.plugins.pda.core.model.form.Form;
+import org.entando.plugins.pda.pam.exception.KieInvalidResponseException;
 import org.entando.plugins.pda.pam.service.api.KieApiService;
 import org.entando.plugins.pda.pam.service.util.KieDefinitionId;
 import org.junit.Before;
@@ -191,14 +192,14 @@ public class KieProcessFormServiceTest {
     }
 
     @Test
-    public void shouldThrowNotFoundWhenSubmitProcessFormWithInvalidContainerId() {
+    public void shouldThrowKieInvalidResponseWhenSubmitProcessFormWithInvalidContainerId() {
         when(uiServicesClient.getProcessForm(anyString(), anyString()))
                 .thenReturn(readFromFile(PROCESS_FORM_JSON_1));
 
         when(processServicesClient.startProcess(anyString(), anyString(), anyMap()))
                 .thenThrow(new KieServicesHttpException(null, HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null));
 
-        expectedException.expect(ProcessDefinitionNotFoundException.class);
+        expectedException.expect(KieInvalidResponseException.class);
 
         kieProcessFormService.submit(connection, PROCESS_DEFINITION_ID, new HashMap<>());
     }

--- a/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentServiceTest.java
+++ b/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentServiceTest.java
@@ -118,7 +118,7 @@ public class KieTaskCommentServiceTest {
 
         // Then
         verify(customQueryService).getGroups(connection, groupName);
-        assertThat(comment.getCreatedBy()).isEqualTo(KieTaskCommentService.PDA_PREFIX + groupName);
+        assertThat(comment.getCreatedBy()).isEqualTo(KieTaskCommentService.PDA_USER_PREFIX + groupName);
     }
 
     @Test

--- a/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentServiceTest.java
+++ b/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskCommentServiceTest.java
@@ -21,6 +21,7 @@ import org.entando.plugins.pda.core.model.Comment;
 import org.entando.plugins.pda.core.service.task.TaskCommentService;
 import org.entando.plugins.pda.core.service.task.request.CreateCommentRequest;
 import org.entando.plugins.pda.pam.exception.KieInvalidIdException;
+import org.entando.plugins.pda.pam.exception.KieInvalidResponseException;
 import org.entando.plugins.pda.pam.service.api.CustomQueryService;
 import org.entando.plugins.pda.pam.service.api.KieApiService;
 import org.entando.plugins.pda.pam.service.util.KieInstanceId;
@@ -169,13 +170,13 @@ public class KieTaskCommentServiceTest {
     }
 
     @Test
-    public void shouldThrowNotFoundWhenGetTaskInternalErrorResponse() {
+    public void shouldThrowKieInvalidResponseWhenGetTaskInternalErrorResponse() {
         // Given
         when(userTaskServicesClient.getTaskCommentById(any(), anyLong(), anyLong()))
                 .thenThrow(new KieServicesHttpException(null, HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null));
 
         // Then
-        expectedException.expect(CommentNotFoundException.class);
+        expectedException.expect(KieInvalidResponseException.class);
 
         // When
         kieTaskService.getComment(getDummyConnection(), null, TASK_1, TASK_COMMENT_1_1);
@@ -195,13 +196,13 @@ public class KieTaskCommentServiceTest {
     }
 
     @Test
-    public void shouldThrowNotFoundWhenDeleteInternalErrorResponse() {
+    public void shouldThrowKieInvalidResponseWhenDeleteInternalErrorResponse() {
         // Given
         doThrow(new KieServicesHttpException(null, HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null))
                 .when(userTaskServicesClient).deleteTaskComment(any(), anyLong(), anyLong());
 
         // Then
-        expectedException.expect(CommentNotFoundException.class);
+        expectedException.expect(KieInvalidResponseException.class);
 
         // When
         kieTaskService.deleteComment(getDummyConnection(), null, TASK_1, TASK_COMMENT_1_1);

--- a/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskFormServiceTest.java
+++ b/src/test/java/org/entando/plugins/pda/pam/service/task/KieTaskFormServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.entando.plugins.pda.core.exception.TaskNotFoundException;
 import org.entando.plugins.pda.core.model.form.Form;
+import org.entando.plugins.pda.pam.exception.KieInvalidResponseException;
 import org.entando.plugins.pda.pam.service.api.KieApiService;
 import org.entando.plugins.pda.pam.service.util.KieInstanceId;
 import org.entando.plugins.pda.pam.util.KieTaskFormTestHelper;
@@ -94,11 +95,11 @@ public class KieTaskFormServiceTest {
     }
 
     @Test
-    public void shouldThrowTaskNotFoundWhenGetFormWithInvalidContainerId() {
+    public void shouldThrowKieInvalidResponseWhenGetFormWithInvalidContainerId() {
         KieInstanceId taskId = new KieInstanceId(randomStringId(), randomLongId());
 
         //Given
-        expectedException.expect(TaskNotFoundException.class);
+        expectedException.expect(KieInvalidResponseException.class);
 
         when(uiServicesClient.getTaskForm(anyString(), anyLong()))
                 .thenThrow(new KieServicesHttpException(null, HttpStatus.INTERNAL_SERVER_ERROR.value(), null, null));
@@ -148,11 +149,11 @@ public class KieTaskFormServiceTest {
     }
 
     @Test
-    public void shouldThrowNotFoundWhenSubmitFormWithInvalidContainerId() {
+    public void shouldThrowKieInvalidResponseWhenSubmitFormWithInvalidContainerId() {
         //Given
         KieInstanceId taskId = new KieInstanceId(randomStringId(), randomLongId());
 
-        expectedException.expect(TaskNotFoundException.class);
+        expectedException.expect(KieInvalidResponseException.class);
 
         when(uiServicesClient.getTaskForm(anyString(), anyLong()))
                 .thenReturn(readFromFile(TASK_FORM_JSON));


### PR DESCRIPTION
When we add a new task comment we are passing the username from the KeyCloak token to the createdBy field. It triggers the addition of the username  in the OrganizationalEntity table, which does not allow a username equals to a existing group name, so we are adding the `user_` prefix when there is a clash.

It's also part of this PR the removal of the logic to convert 500 errors from KieServer to 404. This logic was added because KieServer throws 500 when it cannot find the container. However, there are strong reasons for not doing this convertion:
* It is hidding other errors;
* It happens only when we pass a invalid container id. Since the container id is selected from the dropdown on the config UI as part of the process, it is unlikely that this will happen inside the application;
* As per the error message, it looks like KieServer cannot determine if the container isn't there or if it is not instantiated:
```
Unexpected error during processing: Container 'mortgage-process_1.0.0-SNAPSHOT2' is not instantiated or cannot find container for alias 'mortgage-process_1.0.0-SNAPSHOT2
```
So, it is better to keep the HTTP status code returned by KieServer.